### PR TITLE
Second regex return used, if first undefined

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -94,7 +94,7 @@ function probe(addr, config, callback) {
         for (var t = 0; t < lines.length; t++) {
             var m = regex.exec(lines[t]) || '';
             if (m !== '') {
-                ms = m[1];
+                ms = m[1] || m[2];
                 result = 0;
                 break;
             }


### PR DESCRIPTION
On my machine (macOS Sierra) matches second alternative of regex only ("ttl..*=([0-9\.]*)"). So exec returns time value in m[2] and m[1] is undefined.